### PR TITLE
Make location & free attributes optional

### DIFF
--- a/app/controllers/v1/events_controller.rb
+++ b/app/controllers/v1/events_controller.rb
@@ -10,14 +10,24 @@ module V1
       else
         super
       end
-
     end
 
     private
 
       def event_lookup_params
-        the_params = params.require(:data).require(:attributes).permit(:title, :browser_url)
-        the_params[:location_id] = params[:data].fetch(:relationships, {}).fetch(:location, {}).fetch(:data, {}).fetch(:id)
+        the_params = params.require(:data).require(:attributes).permit(
+          :title,
+          :description,
+          :browser_url,
+          :origin_system,
+          :featured_image_url,
+          :start_date,
+          :end_date)
+          
+          if params[:data].fetch(:relationships, {}).fetch(:location, {}).present?
+            the_params[:location_id] = params[:data].fetch(:relationships, {}).fetch(:location, {}).fetch(:data, {}).fetch(:id)
+          end
+        
         the_params
       end
 

--- a/app/controllers/v1/events_controller.rb
+++ b/app/controllers/v1/events_controller.rb
@@ -15,19 +15,10 @@ module V1
     private
 
       def event_lookup_params
-        the_params = params.require(:data).require(:attributes).permit(
-          :title,
-          :description,
-          :browser_url,
-          :origin_system,
-          :featured_image_url,
-          :start_date,
-          :end_date)
-          
-          if params[:data].fetch(:relationships, {}).fetch(:location, {}).present?
-            the_params[:location_id] = params[:data].fetch(:relationships, {}).fetch(:location, {}).fetch(:data, {}).fetch(:id)
-          end
-        
+        the_params = params.require(:data).require(:attributes).permit(:title, :browser_url)
+        if params[:data].fetch(:relationships, {}).fetch(:location, {}).present?
+          the_params[:location_id] = params[:data].fetch(:relationships, {}).fetch(:location, {}).fetch(:data, {}).fetch(:id)
+        end
         the_params
       end
 

--- a/app/controllers/v1/locations_controller.rb
+++ b/app/controllers/v1/locations_controller.rb
@@ -16,7 +16,7 @@ module V1
   private
 
     def location_lookup_params
-      params.require(:data).require(:attributes).permit(:locality, :region, :postal_code, :venue, :address_lines => [], :identifiers => [], :location => {})
+      params.require(:data).require(:attributes).permit(:address_lines, :locality, :region, :postal_code)
     end
 
   end

--- a/app/controllers/v1/locations_controller.rb
+++ b/app/controllers/v1/locations_controller.rb
@@ -16,7 +16,7 @@ module V1
   private
 
     def location_lookup_params
-      params.require(:data).require(:attributes).permit(:address_lines, :locality, :region, :postal_code)
+      params.require(:data).require(:attributes).permit(:locality, :region, :postal_code, :venue, :address_lines => [], :identifiers => [], :location => {})
     end
 
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,21 +4,19 @@ class Event < ApplicationRecord
 
   serialize :identifiers, Array
 
-  belongs_to :location
+  belongs_to :location, optional: true
   belongs_to :user, optional: true
 
   scope :upcoming, -> { where("start_date >= ?", Date.today).order("start_date") }
-
   scope :past, -> { where("start_date <= ?", Date.today).order("start_date") }
 
   validate :validate_uniqueness, on: [:create, :update]
 
-  validates :title, :browser_url, :origin_system,
-    :start_date, :location_id,
+  validates :title, :browser_url, :origin_system, :start_date,
     presence: true
 
   validates :free,
-    inclusion: { in: [true, false] }
+    inclusion: { in: [true, false, nil] }
 
   after_create :set_identifiers
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe Event, type: :model do
     expect(event.errors[:browser_url]).to_not be_empty
     expect(event.errors[:origin_system]).to_not be_empty
     expect(event.errors[:start_date]).to_not be_empty
-    expect(event.errors[:free]).to_not be_empty
-    expect(event.errors[:location_id]).to_not be_empty
   end
 
   it "does not allow duplicate objects" do


### PR DESCRIPTION
Resistance calendar has events with no location, this commit supports that.