### PR TITLE
Relax validations for creating a location

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -3,7 +3,7 @@ class Location < ApplicationRecord
 
   belongs_to :user, optional: true
 
-  validate :unique_location, :sufficient_location_data_present
+  validate :unique_location
   validates_length_of :region, is: 2, if: -> { self.region }
 
   private
@@ -17,12 +17,6 @@ class Location < ApplicationRecord
     ).first
 
     errors.add(:location, 'already exists') if preexisting_location
-  end
-
-  def sufficient_location_data_present
-    unless (locality && region) || postal_code
-      errors.add(:location, 'requires locality and region or postal_code')
-    end
   end
 
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,21 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Location, type: :model do
-  it "invalid when missing locality, region and postal_code" do
-    loc = described_class.new(address_lines: "123 Fake St.")
-    loc.valid?
-
-    expect(loc.errors[:location]).to eq ['requires locality and region or postal_code']
-  end
-
-  it "invalid with address and locality" do
-    loc = described_class.new(address_lines: "123 Fake St.",
-                              locality: "Milwaukee")
-    loc.valid?
-
-    expect(loc.errors[:location]).to eq ["requires locality and region or postal_code"]
-  end
-
   it "valid with address, locality, region, and postal_code" do
     loc = described_class.new(address_lines: "123 Fake St.",
                               locality: "Milwaukee",


### PR DESCRIPTION
This PR relaxes some of the validations around the location resource.

The PR for grabbing all the resistance calendar data (https://github.com/RagtagOpen/cta-scraper/pull/20)  surfaced these errors and we opted to get grab as much data as possible, which means allowing events that had spotty location data.



