### PR TITLE
Feature/share url field

### DIFF
--- a/app/models/advocacy_campaign.rb
+++ b/app/models/advocacy_campaign.rb
@@ -12,6 +12,8 @@ class AdvocacyCampaign < ApplicationRecord
   validates :title, :description, :origin_system, :action_type,
     presence: true
 
+  validate :share_url_valid?, on: [:create, :update]
+
   after_create :set_identifiers
 
   def target_ids=(ids)
@@ -38,4 +40,9 @@ class AdvocacyCampaign < ApplicationRecord
       self.save(validate: false)
     end
 
+    def share_url_valid?
+      return unless share_url
+      valid_url  = share_url.scan(URI.regexp).any?
+      errors.add(:advocacy_campaign, 'invalid share_url') unless valid_url
+    end
 end

--- a/app/models/advocacy_campaign.rb
+++ b/app/models/advocacy_campaign.rb
@@ -1,4 +1,5 @@
 class AdvocacyCampaign < ApplicationRecord
+  include Validatable
 
   serialize :identifiers, Array
 
@@ -11,8 +12,6 @@ class AdvocacyCampaign < ApplicationRecord
 
   validates :title, :description, :origin_system, :action_type,
     presence: true
-
-  validate :share_url_valid?, on: [:create, :update]
 
   after_create :set_identifiers
 
@@ -40,9 +39,4 @@ class AdvocacyCampaign < ApplicationRecord
       self.save(validate: false)
     end
 
-    def share_url_valid?
-      return unless share_url
-      valid_url  = share_url.scan(URI.regexp).any?
-      errors.add(:advocacy_campaign, 'invalid share_url') unless valid_url
-    end
 end

--- a/app/models/concerns/validatable.rb
+++ b/app/models/concerns/validatable.rb
@@ -1,0 +1,13 @@
+module Validatable
+  extend ActiveSupport::Concern
+
+  included do
+    validate :share_url_valid?, on: [:create, :update]
+  end
+
+  def share_url_valid?
+    return unless share_url
+    valid_url  = share_url.scan(URI.regexp).any?
+    errors.add(:advocacy_campaign, 'invalid share_url') unless valid_url
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ApplicationRecord
+  include Validatable
 
   attr_accessor :identifier
 

--- a/app/resources/v1/advocacy_campaign_resource.rb
+++ b/app/resources/v1/advocacy_campaign_resource.rb
@@ -1,7 +1,7 @@
 module V1
   class AdvocacyCampaignResource < BaseResource
     attributes :title, :description, :browser_url, :origin_system,
-      :featured_image_url, :action_type, :template, :target_list, :identifiers
+      :featured_image_url, :action_type, :template, :target_list, :identifiers, :share_url
 
     has_one :user
     has_many :targets

--- a/app/resources/v1/event_resource.rb
+++ b/app/resources/v1/event_resource.rb
@@ -1,7 +1,7 @@
 module V1
   class EventResource < BaseResource
     attributes :title, :description, :browser_url, :origin_system,
-      :featured_image_url, :start_date, :end_date, :free, :identifiers
+      :featured_image_url, :start_date, :end_date, :free, :identifiers, :share_url
 
     has_one :location
     has_one :user

--- a/db/migrate/20171014202558_alter_advocacy_camaign_add_share_url_col.rb
+++ b/db/migrate/20171014202558_alter_advocacy_camaign_add_share_url_col.rb
@@ -1,0 +1,5 @@
+class AlterAdvocacyCamaignAddShareUrlCol < ActiveRecord::Migration[5.0]
+  def change
+    add_column :advocacy_campaigns, :share_url, :string
+  end
+end

--- a/db/migrate/20171018024140_alter_events_add_share_col.rb
+++ b/db/migrate/20171018024140_alter_events_add_share_col.rb
@@ -1,0 +1,5 @@
+class AlterEventsAddShareCol < ActiveRecord::Migration[5.0]
+  def change
+    add_column :events, :share_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170821030113) do
+ActiveRecord::Schema.define(version: 20171014202558) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 20170821030113) do
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
     t.text     "identifiers"
+    t.string   "share_url"
     t.index ["user_id"], name: "index_advocacy_campaigns_on_user_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171014202558) do
+ActiveRecord::Schema.define(version: 20171018024140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 20171014202558) do
     t.datetime "updated_at",         null: false
     t.uuid     "user_id"
     t.text     "identifiers"
+    t.string   "share_url"
   end
 
   create_table "locations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/spec/factories/advocacy_campaigns.rb
+++ b/spec/factories/advocacy_campaigns.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     action_type { ['email', 'in-person', 'phone', 'postal mail'].sample }
     template { Faker::Lorem.paragraphs.join("\n") }
     user_id { SecureRandom.uuid }
+    share_url { Faker::Internet.url('shareablecontent.com') }
 
     transient do
       target_count 0

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     end_date { [4,5,6].sample.days.from_now }
     free { [true, false].sample }
     location { create(:location) }
+    share_url { Faker::Internet.url('shareablecontent.com') }
 
     trait :free do
       free true

--- a/spec/models/advocacy_campaign_spec.rb
+++ b/spec/models/advocacy_campaign_spec.rb
@@ -24,4 +24,19 @@ RSpec.describe AdvocacyCampaign, type: :model do
     expect { described_class.create!(advocacy_campaign_attrs) }.to raise_error(ActiveRecord::RecordInvalid)
   end
 
+  it "expects properly formatted share_urls" do
+    advocacy_campaign = FactoryGirl.build(:advocacy_campaign, share_url: 'foo')
+    expect(advocacy_campaign.valid?).to be false
+    advocacy_campaign.share_url = 'www.facebook.com/bleh'
+    expect(advocacy_campaign.valid?).to be false
+    advocacy_campaign.share_url = 'http://www.facebook.com/bleh'
+    expect(advocacy_campaign.valid?).to be true
+    advocacy_campaign.share_url = 'https://www.facebook.com/bleh'
+    expect(advocacy_campaign.valid?).to be true
+    advocacy_campaign.share_url = 'https://facebook.com/bleh'
+    expect(advocacy_campaign.valid?).to be true
+    advocacy_campaign.share_url = 'https://facebook.com/bleh?ping=pong'
+    expect(advocacy_campaign.valid?).to be true
+  end
+
 end

--- a/spec/models/advocacy_campaign_spec.rb
+++ b/spec/models/advocacy_campaign_spec.rb
@@ -24,19 +24,6 @@ RSpec.describe AdvocacyCampaign, type: :model do
     expect { described_class.create!(advocacy_campaign_attrs) }.to raise_error(ActiveRecord::RecordInvalid)
   end
 
-  it "expects properly formatted share_urls" do
-    advocacy_campaign = FactoryGirl.build(:advocacy_campaign, share_url: 'foo')
-    expect(advocacy_campaign.valid?).to be false
-    advocacy_campaign.share_url = 'www.facebook.com/bleh'
-    expect(advocacy_campaign.valid?).to be false
-    advocacy_campaign.share_url = 'http://www.facebook.com/bleh'
-    expect(advocacy_campaign.valid?).to be true
-    advocacy_campaign.share_url = 'https://www.facebook.com/bleh'
-    expect(advocacy_campaign.valid?).to be true
-    advocacy_campaign.share_url = 'https://facebook.com/bleh'
-    expect(advocacy_campaign.valid?).to be true
-    advocacy_campaign.share_url = 'https://facebook.com/bleh?ping=pong'
-    expect(advocacy_campaign.valid?).to be true
-  end
+  include_examples "share_url examples", FactoryGirl.build(:advocacy_campaign)
 
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -17,4 +17,6 @@ RSpec.describe Event, type: :model do
 
     expect { described_class.create!(event_attrs) }.to raise_error(ActiveRecord::RecordInvalid)
   end
+
+  include_examples "share_url examples", FactoryGirl.build(:event)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ require 'simplecov'
 SimpleCov.start 'rails'
 
 require 'support/request_helpers'
+require 'support/shared_examples/share_url_examples'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/shared_examples/share_url_examples.rb
+++ b/spec/support/shared_examples/share_url_examples.rb
@@ -1,0 +1,18 @@
+RSpec.shared_examples 'share_url examples' do |subject|
+
+  it "expects properly formatted share_urls" do
+    subject.share_url = 'foo'
+    expect(subject.valid?).to be false
+    subject.share_url = 'www.facebook.com/bleh'
+    expect(subject.valid?).to be false
+    subject.share_url = 'http://www.facebook.com/bleh'
+    expect(subject.valid?).to be true
+    subject.share_url = 'https://www.facebook.com/bleh'
+    expect(subject.valid?).to be true
+    subject.share_url = 'https://facebook.com/bleh'
+    expect(subject.valid?).to be true
+    subject.share_url = 'https://facebook.com/bleh?ping=pong'
+    expect(subject.valid?).to be true
+  end
+
+end


### PR DESCRIPTION
This PR adds a "share_url" field to the AdvovacyCampaign and Event models.
